### PR TITLE
Change License to the one originally used in original repo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,52 @@
-    MIT License
+Copyright (c) 2006, Google Inc.
+Portions Copyright (c) Microsoft Corporation
 
-    Copyright (c) Microsoft Corporation. All rights reserved.
+All rights reserved.
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------
+
+Copyright 2001-2004 Unicode, Inc.
+
+Disclaimer
+
+This source code is provided as is by Unicode, Inc. No claims are
+made as to fitness for any particular purpose. No warranties of any
+kind are expressed or implied. The recipient agrees to determine
+applicability of information provided. If this file has been
+purchased on magnetic or optical media from Unicode, Inc., the
+sole remedy for any claim will be exchange of defective media
+within 90 days of receipt.
+
+Limitations on Rights to Redistribute This Code
+
+Unicode, Inc. hereby grants the right to freely use the information
+supplied in this file in the creation of products supporting the
+Unicode Standard, and to make copies of this file in any form
+for internal or external distribution as long as this notice
+remains attached.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -7,7 +7,34 @@
                 "repositoryUrl": "https://chromium.googlesource.com/linux-syscall-support", 
                 "commitHash": "a89bf7903f3169e6bc7b8efc10a73a7571de21cf" 
                 }
+            }
+        },
+        {
+            "component": { 
+                "type": "git", 
+                "git": { 
+                "repositoryUrl": "https://github.com/google/googletest.git", 
+                "commitHash": "ec44c6c1675c25b9827aacd08c02433cccde7780" 
                 }
+            }
+        },
+        {
+            "component": { 
+                "type": "git", 
+                "git": { 
+                "repositoryUrl": "https://github.com/google/protobuf.git", 
+                "commitHash": "cb6dd4ef5f82e41e06179dcd57d3b1d9246ad6ac" 
+                }
+            }
+        },
+        {
+            "component": { 
+                "type": "git", 
+                "git": { 
+                "repositoryUrl": "https://chromium.googlesource.com/external/gyp/", 
+                "commitHash": "324dd166b7c0b39d513026fa52d6280ac6d56770" 
+                }
+            }
         }
     ],
     "Version": 1

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,0 +1,14 @@
+{
+    "Registrations":[ 
+        {
+            "component": { 
+                "type": "git", 
+                "git": { 
+                "repositoryUrl": "https://chromium.googlesource.com/linux-syscall-support", 
+                "commitHash": "a89bf7903f3169e6bc7b8efc10a73a7571de21cf" 
+                }
+                }
+        }
+    ],
+    "Version": 1
+}


### PR DESCRIPTION
This PR will sync the License with the one originally used on main repo and add manifest file for CG on CI.
[AB#78940](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/78940)